### PR TITLE
Fix, test transaction decoding

### DIFF
--- a/src/bitcoinrpcclient/bitcoinrpcclient.go
+++ b/src/bitcoinrpcclient/bitcoinrpcclient.go
@@ -62,7 +62,7 @@ func (rpcClient *BitcoinRPCClient) waitTillRPCServerReady(timeout time.Duration)
 			return nil
 		}
 	}
-	return fmt.Errorf("timedout after %s while waiting for the Bitcoin Core RPC Server to be ready", timeout)
+	return fmt.Errorf("timed out after %s while waiting for the Bitcoin Core RPC Server to be ready", timeout)
 }
 
 // GenerateToAddress mines `nBlocks` to the passed address and returns the block

--- a/src/zmqsubscriber/zmqsubscriber.go
+++ b/src/zmqsubscriber/zmqsubscriber.go
@@ -154,7 +154,7 @@ func parseTransaction(firstSeen time.Time, payload [][]byte) (*types.Transaction
 
 	// payload[1] contains a 16bit LE sequence number provided by Bitcoin Core,
 	// which is not used here, but noted for completeness.
-	// rawtxwithfee is the rawtx by Bitcoin Core concatinated with the 8 byte BE
+	// rawtxwithfee is the rawtx by Bitcoin Core concatinated with the 8 byte LE
 	// transaction fee. This is a patch from the branch
 	// https://github.com/0xB10C/bitcoin/tree/2019-10-rawtxwithfee-zmq-publisher
 	rawtxwithfee, _ := payload[0], payload[1]
@@ -174,7 +174,7 @@ func parseTransaction(firstSeen time.Time, payload [][]byte) (*types.Transaction
 	wireTxHash := wireTx.TxHash()
 	copy(txid[:], []byte(wireTxHash.CloneBytes()))
 
-	fee := binary.BigEndian.Uint64(feeBytes)
+	fee := binary.LittleEndian.Uint64(feeBytes)
 	weight := wireTx.SerializeSizeStripped()*3 + wireTx.SerializeSize()
 
 	return &types.Transaction{

--- a/src/zmqsubscriber/zmqsubscriber_test.go
+++ b/src/zmqsubscriber/zmqsubscriber_test.go
@@ -2,6 +2,7 @@ package zmqsubscriber
 
 import (
 	"fmt"
+	"github.com/stretchr/testify/assert"
 	"log"
 	"os"
 	"testing"
@@ -96,8 +97,11 @@ func TestZMQSubscriber(t *testing.T) {
 	require.NotNil(t, waitForZMQBlock(t, z, zmqWaitTimeout))
 
 	_, err = rpcClient.SendSimpleTransaction(addressSendTo)
+	tx := waitForZMQTransaction(t, z, zmqWaitTimeout)
 	require.NoError(t, err)
-	require.NotNil(t, waitForZMQTransaction(t, z, zmqWaitTimeout))
+	require.NotNil(t, tx)
+	assert.InDelta(t, 250, int(tx.Fee), 250)
+	assert.InDelta(t, 500, int(tx.Weight), 500)
 
 	_, err = rpcClient.GenerateToAddress(1, addressMineTo)
 	require.NoError(t, err)


### PR DESCRIPTION
0f416fd (Otto Allmendinger, 20 minutes ago)
   Fix, test transaction decoding

   * Fee encoding is little endian instead of big endian.
   * Test fee and weight (approximately)

6c960cb (Otto Allmendinger, 15 minutes ago)
   Makefile: split off test-bitcoind-start, -stop

   This allows running test subset outside of `make`

   ``` 
TEST_INTEGRATION_RPC_HOST=127.0.0.1
TEST_INTEGRATION_RPC_PORT=18443
TEST_INTEGRATION_RPC_USER=use-for-regtest-and-ci-only
TEST_INTEGRATION_RPC_PASS=0rU3Doo7M6FCPc8SmBB2aLqUEd6b1Jgcl-o-c86JJ9k=
TEST_INTEGRATION_ZMQ_HOST=0.0.0.0" TEST_INTEGRATION_ZMQ_PORT=28334"
   ```