### PR TITLE
Storage: transaction table improvements

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,5 +7,6 @@ require (
 	github.com/btcsuite/btcutil v0.0.0-20190425235716-9e5f4b9a998d
 	github.com/mattn/go-sqlite3 v1.11.0
 	github.com/pebbe/zmq4 v1.0.0
+	github.com/pkg/errors v0.8.1
 	github.com/stretchr/testify v1.4.0
 )

--- a/go.sum
+++ b/go.sum
@@ -28,6 +28,8 @@ github.com/onsi/ginkgo v1.7.0/go.mod h1:lLunBs/Ym6LB5Z9jYTR76FiuTmxDTDusOGeTQH+W
 github.com/onsi/gomega v1.4.3/go.mod h1:ex+gbHU/CVuBBDIJjb2X0qEXbFg53c61hWP/1CpauHY=
 github.com/pebbe/zmq4 v1.0.0 h1:D+MSmPpqkL5PSSmnh8g51ogirUCyemThuZzLW7Nrt78=
 github.com/pebbe/zmq4 v1.0.0/go.mod h1:7N4y5R18zBiu3l0vajMUWQgZyjv464prE8RCyBcmnZM=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
+github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=

--- a/src/daemon/daemon.go
+++ b/src/daemon/daemon.go
@@ -33,7 +33,8 @@ func NewBademeisterDaemon(host, port, dbPath string) (*BademeisterDaemon, error)
 
 func (b *BademeisterDaemon) processTransaction(tx *types.Transaction) error {
 	log.Printf("Received transaction, adding to storage")
-	return b.storage.InsertTransaction(tx)
+	_, err := b.storage.InsertTransaction(tx)
+	return err
 }
 
 func (b *BademeisterDaemon) processBlock(block *types.Block) error {
@@ -65,12 +66,12 @@ func (b *BademeisterDaemon) Run() error {
 			return zmqSubErr
 		case tx := <-b.zmqSub.IncomingTx:
 			if err := b.processTransaction(&tx); err != nil {
-				log.Printf("Error in processTransaction()")
+				log.Printf("Error in processTransaction(): %s", err)
 				return err
 			}
 		case block := <-b.zmqSub.IncomingBlocks:
 			if err := b.processBlock(&block); err != nil {
-				log.Printf("Error in processBlock()")
+				log.Printf("Error in processBlock(): %s", err)
 				return err
 			}
 		}

--- a/src/storage/storage_test.go
+++ b/src/storage/storage_test.go
@@ -2,121 +2,47 @@ package storage
 
 import (
 	"crypto/sha256"
-	"os"
-	"testing"
-	"time"
-
+	"fmt"
 	"github.com/0xb10c/bademeister-go/src/types"
-	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	"os"
+	"time"
 )
 
-func testQueryTransactions(t *testing.T, st *Storage, firstSeen time.Time, txs []types.Transaction) {
-	// test query all txs
-	{
-		txIter, err := st.QueryTransactions(Query{})
-		require.NoError(t, err)
+// GenerateHash32 returns the hash of a provided preimage.
+func GenerateHash32(in string) types.Hash32 {
+	return sha256.Sum256([]byte(in))
+}
 
-		recoverTx := txIter.Next()
-		require.NotNil(t, recoverTx)
-		assert.Equal(t, txs[0], *recoverTx)
+// The nanoseconds are truncated, because the precision is lost
+// when writing the firstSeen unix timestamp to database.
+// Not truncating would result in unequal transactions when
+// comparing with assert.Equal().
+var startTime = time.Unix(0, 0).UTC().Truncate(time.Second)
 
-		recoverTx = txIter.Next()
-		require.NotNil(t, recoverTx)
-		assert.Equal(t, txs[1], *recoverTx)
+func GetTime(offsetSeconds int) time.Time {
+	return startTime.Add(time.Duration(offsetSeconds) * time.Second)
+}
 
-		assert.Nil(t, txIter.Next())
-	}
-
-	// test query with FirstSeen
-	{
-		txIter, err := st.QueryTransactions(Query{
-			FirstSeen: &firstSeen,
-		})
-		require.NoError(t, err)
-
-		recoverTx := txIter.Next()
-		require.NotNil(t, recoverTx)
-		assert.Equal(t, txs[1], *recoverTx)
-
-		assert.Nil(t, txIter.Next())
+func NewTxAtOffset(offsetSeconds int) *types.Transaction {
+	return &types.Transaction{
+		TxID:      GenerateHash32(fmt.Sprintf("tx-%d", offsetSeconds)),
+		FirstSeen: GetTime(offsetSeconds),
+		Fee:       uint64(100 + offsetSeconds),
+		Weight:    100 + offsetSeconds,
 	}
 }
 
-// generateTestTxID returns the hash of a provided preimage.
-func generateTestTxID(preimage []byte) types.Hash32 {
-	return sha256.Sum256(preimage)
-}
-
-func TestStorage(t *testing.T) {
-	if testing.Short() {
-		t.Skip("Skipping " + t.Name() + " since it's not a unit test.")
-	}
-
+func StoragePath() string {
 	// The environment variable `TEST_INTEGRATION_DIR` is set to a temporary
 	// directory created by the Makefile in the target `test-integration`.
 	integrationTestDir := os.Getenv("TEST_INTEGRATION_DIR")
-	path := integrationTestDir + "/mempool.db"
+	return integrationTestDir + "/mempool.db"
+}
 
-	st, err := NewStorage(path)
-	require.NoError(t, err)
-
-	// The nanoseconds are truncated, because the precision is lost
-	// when writing the firstSeen unix timestamp to database.
-	// Not truncating would result in unequal transactions when
-	// comparing with assert.Equal().
-	tm := time.Now().UTC().Truncate(time.Second)
-	txs := []types.Transaction{
-		{
-			TxID:      generateTestTxID([]byte("tx 1")),
-			FirstSeen: tm,
-			Fee:       232,
-			Weight:    489,
-		},
-		{
-			TxID:      generateTestTxID([]byte("tx 2")),
-			FirstSeen: tm.Add(10 * time.Second),
-			Fee:       1234567890,
-			Weight:    12345,
-		},
+func NewTestStorage() (*Storage, error) {
+	if err := os.Remove(StoragePath()); err != nil && !os.IsNotExist(err) {
+		return nil, fmt.Errorf(`could not reset mempool.db: %s`, err)
 	}
 
-	for _, tx := range txs {
-		err := st.InsertTransaction(&tx)
-		require.NoError(t, err)
-	}
-
-	testQueryTransactions(t, st, tm, txs)
-	err = st.Close()
-
-	// re-open, req-run query tests
-	st, err = NewStorage(path)
-	require.NoError(t, err)
-	defer st.Close()
-	testQueryTransactions(t, st, tm, txs)
-
-	// repeated insertion with same txid upserts iff FirstSeen is lower
-	{
-		err = st.InsertTransaction(&txs[0])
-		require.NoError(t, err)
-		testQueryTransactions(t, st, tm, txs)
-
-		txLater := txs[0]
-		txLater.FirstSeen = txLater.FirstSeen.Add(10 * time.Second)
-		err = st.InsertTransaction(&txLater)
-		require.NoError(t, err)
-		testQueryTransactions(t, st, tm, txs)
-	}
-
-	{
-		txEarlier := txs[0]
-		txEarlier.FirstSeen = txEarlier.FirstSeen.Add(-10 * time.Second)
-		err = st.InsertTransaction(&txEarlier)
-		require.NoError(t, err)
-		testQueryTransactions(t, st, tm, []types.Transaction{txEarlier, txs[1]})
-	}
-
-	count, err := st.TxCount()
-	assert.NoError(t, err)
-	assert.Equal(t, 2, count)
+	return NewStorage(StoragePath())
 }

--- a/src/storage/storage_transaction.go
+++ b/src/storage/storage_transaction.go
@@ -1,0 +1,221 @@
+package storage
+
+import (
+	"database/sql"
+	"fmt"
+	"github.com/0xb10c/bademeister-go/src/types"
+	"github.com/pkg/errors"
+	"strings"
+	"time"
+)
+
+
+type ErrorLookupTransactionDBIDs struct {
+	MissingTxs []types.Hash32
+	Total      int
+}
+
+func (e *ErrorLookupTransactionDBIDs) Error() string {
+	return fmt.Sprintf("could not find %d of %d transactions", len(e.MissingTxs), e.Total)
+}
+
+func IsErrorMissingTransactions(err error) bool {
+	_, ok := err.(*ErrorLookupTransactionDBIDs)
+	return ok
+}
+
+
+type TransactionQueryByTime struct {
+	FirstSeenBeforeOrAt *time.Time
+	LastRemovedAfter    *time.Time
+}
+
+func (r TransactionQueryByTime) Where() string {
+	clause := []string{}
+	if r.FirstSeenBeforeOrAt != nil {
+		clause = append(clause, fmt.Sprintf(
+			"(first_seen <= %d)", r.FirstSeenBeforeOrAt.Unix(),
+		))
+	}
+	if r.LastRemovedAfter != nil {
+		clause = append(clause, fmt.Sprintf(
+			"((last_removed IS NULL) OR (last_removed > %d))",
+			r.LastRemovedAfter.Unix(),
+		))
+	}
+	return strings.Join(clause, " AND ")
+}
+
+func (q TransactionQueryByTime) Order() string {
+	return ""
+}
+
+func (q TransactionQueryByTime) Limit() int {
+	return 0
+}
+
+type TxIterator struct {
+	rows *sql.Rows
+}
+
+func (i *TxIterator) Next() *types.StoredTransaction {
+	if !i.rows.Next() {
+		return nil
+	}
+
+	var txidBytes []byte
+	var firstSeenSeconds int64
+	var lastRemovedSeconds *int64
+	var tx types.StoredTransaction
+	err := i.rows.Scan(
+		&tx.DBID,
+		&txidBytes,
+		&firstSeenSeconds,
+		&lastRemovedSeconds,
+		&tx.Fee,
+		&tx.Weight,
+	)
+
+	tx.TxID = types.NewHashFromBytes(txidBytes)
+	tx.FirstSeen = time.Unix(firstSeenSeconds, 0).UTC()
+	if lastRemovedSeconds != nil {
+		lastRemoved := time.Unix(*lastRemovedSeconds, 0).UTC()
+		tx.LastRemoved = &lastRemoved
+	}
+
+	if err != nil {
+		panic(err)
+	}
+
+	return &tx
+}
+
+func (i TxIterator) Collect() (res []types.StoredTransaction) {
+	defer i.Close()
+	for tx := i.Next(); tx != nil; tx = i.Next() {
+		res = append(res, *tx)
+	}
+	return res
+}
+
+func (i *TxIterator) Close() error {
+	return i.rows.Close()
+}
+
+
+func (s *Storage) InsertTransaction(tx *types.Transaction) (int64, error) {
+	const insertTransaction string = `
+	INSERT INTO "transaction" (txid, first_seen, fee, weight) VALUES(?, ?, ?, ?)
+	ON CONFLICT(txid) DO
+		UPDATE SET
+			first_seen = excluded.first_seen
+		WHERE
+			first_seen > excluded.first_seen
+	`
+
+	// The firstSeen timestamp might not be to be monotonic, since transactions
+	// can be inserted from multiple sources (ZMQ and getrawmempool RPC).
+	// https://www.sqlite.org/lang_UPSERT.html
+	res, err := s.db.Exec(insertTransaction, tx.TxID[:], tx.FirstSeen.UTC().Unix(), tx.Fee, tx.Weight)
+	if err != nil {
+		return 0, errors.Errorf("could not insert a transaction into table `transaction`: %s", err)
+	}
+	id, err := res.LastInsertId()
+	if err != nil {
+		return 0, err
+	}
+	return id, nil
+}
+
+func (s *Storage) transactionDBIDs(txids []types.Hash32) (*[]int64, error) {
+	inClause := []string{}
+	for _, txid := range txids {
+		inClause = append(inClause, fmt.Sprintf("x'%s'", txid))
+	}
+
+	selectTransactionIds := fmt.Sprintf(`
+		SELECT 
+			id, txid
+		FROM 
+			"transaction" 
+		WHERE 
+			txid IN (%s)
+		`, strings.Join(inClause, ","),
+	)
+
+	rows, err := s.db.Query(selectTransactionIds)
+	if err != nil {
+		return nil, errors.Errorf("error getting database ids from transactions: %s", err)
+	}
+
+	dbidByTxId := map[types.Hash32]int64{}
+
+	for rows.Next() {
+		var dbid int64
+		var txidBytes []byte
+
+		err := rows.Scan(&dbid, &txidBytes)
+		if err != nil {
+			return nil, errors.Errorf("error reading row: %s", err)
+		}
+
+		dbidByTxId[types.NewHashFromBytes(txidBytes)] = dbid
+	}
+
+	missing := []types.Hash32{}
+	res := []int64{}
+	for _, txid := range txids {
+		if dbid, ok := dbidByTxId[txid]; ok {
+			res = append(res, dbid)
+		} else {
+			missing = append(missing, txid)
+		}
+	}
+
+	if len(missing) > 0 {
+		return nil, &ErrorLookupTransactionDBIDs{
+			MissingTxs: missing,
+			Total:      len(txids),
+		}
+	}
+
+	return &res, nil
+}
+
+func (s *Storage) QueryTransactions(q Query) (*TxIterator, error) {
+	var rows *sql.Rows
+	var err error
+
+	rows, err = s.db.Query(formatQuery(
+		[]string{"id", "txid", "first_seen", "last_removed", "fee", "weight"},
+		"transaction",
+		q,
+	))
+
+	if err != nil {
+		return nil, errors.Wrapf(err, "error in transaction query %v", q)
+	}
+
+	return &TxIterator{rows}, nil
+}
+
+func (s *Storage) TransactionById(txid types.Hash32) (*types.StoredTransaction, error) {
+	txIter, err := s.QueryTransactions(StaticQuery{
+		where: fmt.Sprintf("txid = x'%s'", txid),
+		limit: 1,
+	})
+	if err != nil {
+		return nil, err
+	}
+	defer txIter.Close()
+	return txIter.Next(), nil
+}
+
+func (s *Storage) NextTransactions(t time.Time, dbid int64, limit int) (*TxIterator, error) {
+	return s.QueryTransactions(StaticQuery{
+		// since there can be multiple txs with the same timestamp, we must use the dbid to query as well
+		where: fmt.Sprintf("(first_seen >= %d) AND (id > %d)", t.Unix(), dbid),
+		order: "first_seen ASC, id ASC",
+		limit: limit,
+	})
+}

--- a/src/storage/storage_transaction_test.go
+++ b/src/storage/storage_transaction_test.go
@@ -1,0 +1,127 @@
+package storage
+
+import (
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/0xb10c/bademeister-go/src/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testQueryTransactions(t *testing.T, st *Storage, txs []types.Transaction) {
+	// test query all txs
+	txIter, err := st.QueryTransactions(StaticQuery{})
+	require.NoError(t, err)
+	defer txIter.Close()
+
+	recoverTx := txIter.Next()
+	require.NotNil(t, recoverTx)
+	assert.Equal(t, txs[0], recoverTx.Transaction)
+
+	recoverTx = txIter.Next()
+	require.NotNil(t, recoverTx)
+	assert.Equal(t, txs[1], recoverTx.Transaction)
+
+	recoverTx = txIter.Next()
+	assert.Nil(t, recoverTx)
+}
+
+func TestStorage_InsertTransaction(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping " + t.Name() + " since it's not a unit test.")
+	}
+
+	st, err := NewTestStorage()
+	require.NoError(t, err)
+
+	txs := []types.Transaction{
+		*NewTxAtOffset(0),
+		*NewTxAtOffset(10),
+	}
+
+	for _, tx := range txs {
+		_, err := st.InsertTransaction(&tx)
+		require.NoError(t, err)
+	}
+
+	testQueryTransactions(t, st, txs)
+	err = st.Close()
+	require.NoError(t, err)
+
+	// re-open, req-run query tests
+	st, err = NewStorage(StoragePath())
+	require.NoError(t, err)
+	defer st.Close()
+	testQueryTransactions(t, st, txs)
+
+	// repeated insertion with same txid upserts iff FirstSeen is lower
+	{
+		_, err = st.InsertTransaction(&txs[0])
+		require.NoError(t, err)
+		testQueryTransactions(t, st, txs)
+
+		txLater := txs[0]
+		txLater.FirstSeen = txLater.FirstSeen.Add(10 * time.Second)
+		_, err = st.InsertTransaction(&txLater)
+		require.NoError(t, err)
+		testQueryTransactions(t, st, txs)
+	}
+
+	{
+		txEarlier := txs[0]
+		txEarlier.FirstSeen = txEarlier.FirstSeen.Add(-10 * time.Second)
+		_, err = st.InsertTransaction(&txEarlier)
+		require.NoError(t, err)
+		testQueryTransactions(t, st, []types.Transaction{txEarlier, txs[1]})
+	}
+
+	count, err := st.TxCount()
+	assert.NoError(t, err)
+	assert.Equal(t, 2, count)
+}
+
+func TestStorage_NextTransactions(t *testing.T) {
+	if testing.Short() {
+		t.Skip("Skipping " + t.Name() + " since it's not a unit test.")
+	}
+
+	st, err := NewTestStorage()
+	require.NoError(t, err)
+	defer st.Close()
+
+	for i := 0; i < 8; i++ {
+		for j := 0; j < 8; j++ {
+			tx := types.Transaction{
+				TxID:      GenerateHash32(fmt.Sprintf("tx-%d-%d", i, j)),
+				FirstSeen: GetTime(i),
+			}
+			dbid, err := st.InsertTransaction(&tx)
+			require.Equal(t, int64(i*8+j+1), dbid)
+			require.NoError(t, err)
+		}
+	}
+
+	tx := &types.StoredTransaction{}
+	tm := GetTime(0)
+	for i := 1; ; i++ {
+		txIter, err := st.NextTransactions(tm, tx.DBID, 1)
+		require.NoError(t, err)
+		defer txIter.Close()
+
+		tx = txIter.Next()
+		if tx == nil {
+			break
+		}
+		tm = tx.FirstSeen
+
+		assert.Equal(t, int64(i), tx.DBID)
+
+		if i > 8*8 {
+			t.Logf("invalid result count")
+			t.Fail()
+		}
+	}
+}
+

--- a/src/types/block.go
+++ b/src/types/block.go
@@ -3,11 +3,17 @@ package types
 import "time"
 
 type Block struct {
-	Hash         Hash32        `json:"hash"`
-	FirstSeen    time.Time     `json:"firstSeen"`
-	Height       uint32        `json:"height"`
-	Transactions []Transaction `json:"transactions"`
-	EncodedTime  time.Time     `json:"encodedTime"` // TODO: find a better name for this?
+	Hash        Hash32    `json:"hash"`
+	Parent      Hash32    `json:"parent"`
+	FirstSeen   time.Time `json:"firstSeen"`
+	Height      uint32    `json:"height"`
+	IsBest      bool      `json:"isBest"`
+	TxIDs       []Hash32  `json:"txids"`
+	EncodedTime time.Time `json:"encodedTime"` // TODO: find a better name for this?
 	// TODO: Size ?
+}
 
+type StoredBlock struct {
+	DBID int64
+	Block
 }

--- a/src/types/hash.go
+++ b/src/types/hash.go
@@ -1,6 +1,9 @@
 package types
 
-import "encoding/hex"
+import (
+	"encoding/hex"
+	"fmt"
+)
 
 // Hash32 is a 32 byte / 256 bit hash.
 // This hash is used for block header hashes and transaction IDs.
@@ -8,4 +11,17 @@ type Hash32 [32]byte
 
 func (h Hash32) String() string {
 	return hex.EncodeToString(h[:])
+}
+
+func NewHashFromBytes(bytes []byte) (res Hash32) {
+	if len(bytes) != 32 {
+		// for ergonomics, we do not return an error here
+		panic(fmt.Errorf("invalid hash length"))
+	}
+	copy(res[:], bytes)
+	return
+}
+
+func NewHashFromArray(bytes [32]byte) Hash32 {
+	return NewHashFromBytes(bytes[:])
 }

--- a/src/types/transaction.go
+++ b/src/types/transaction.go
@@ -6,10 +6,16 @@ import (
 
 // Transaction represents a Bitcoin transaction
 type Transaction struct {
-	TxID         Hash32    `json:"txid"`
-	FirstSeen    time.Time `json:"firstSeen"`
-	Fee          uint64    `json:"fee"`
-	Weight       int       `json:"weight"`
-	BlockHeight  int32     `json:"blockHeight"`
-	IndexInBlock int32     `json:"indexInBlock"`
+	TxID         Hash32     `json:"txid"`
+	FirstSeen    time.Time  `json:"firstSeen"`
+	LastRemoved  *time.Time `json:"lastRemoved"`
+	Fee          uint64     `json:"fee"`
+	Weight       int        `json:"weight"`
+	BlockHeight  int32      `json:"blockHeight"`
+	IndexInBlock int32      `json:"indexInBlock"`
+}
+
+type StoredTransaction struct {
+	DBID int64
+	Transaction
 }

--- a/src/zmqsubscriber/zmqsubscriber.go
+++ b/src/zmqsubscriber/zmqsubscriber.go
@@ -170,9 +170,7 @@ func parseTransaction(firstSeen time.Time, payload [][]byte) (*types.Transaction
 		return nil, fmt.Errorf("could not deserialize the rawtx as wire.MsgTx: %s", err)
 	}
 
-	var txid types.Hash32
-	wireTxHash := wireTx.TxHash()
-	copy(txid[:], []byte(wireTxHash.CloneBytes()))
+	txid := types.NewHashFromArray(wireTx.TxHash())
 
 	fee := binary.LittleEndian.Uint64(feeBytes)
 	weight := wireTx.SerializeSizeStripped()*3 + wireTx.SerializeSize()


### PR DESCRIPTION
This is mainly a change in preparation of the addition of the `block`
and `transaction_block` tables.

* Add `github.com/pkg/errors` for error handling. The main reason is
  that errors created by that package have stack traces by default. We
  should use that package for other errors as well in later changes.
* Move methods mainly related to transaction table to
  `storage_transaction.go`
* Extend `TxIterator` a bit
* Move transaction tests to `storage_transaction.go`
* Add minimal `Query` interface and `StaticQuery` wrapper